### PR TITLE
Added braces around initialization of arrays in main.c and view.c files

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -7,7 +7,7 @@
 #include "score.h"
 #include "timer.h"
 
-char Table[ROWS_TABLE][COLS_TABLE] = {0};
+char Table[ROWS_TABLE][COLS_TABLE] = {{0}};
 Piece Current;
 
 static int canGameContinue()

--- a/src/view.c
+++ b/src/view.c
@@ -21,7 +21,7 @@ static void deployPieceInTable(const Piece piece, char pieceInTable[ROWS_TABLE][
 
 void printTable(const Piece current, const char table[ROWS_TABLE][COLS_TABLE], const int score)
 {
-	char pieceInTable[ROWS_TABLE][COLS_TABLE] = {0};
+	char pieceInTable[ROWS_TABLE][COLS_TABLE] = {{0}};
 	deployPieceInTable(current, pieceInTable);
 	clear();
 	for (int i = 0; i < COLS_TABLE - OFFSET_HEADER; i++)


### PR DESCRIPTION
#32 main.c, view.cファイルにてmake時以下のエラーが出ていたことに起因する対応。
```
error: suggest braces around initialization of subobject
```

中括弧を二重にして対応。(以下一部抜粋)
```
char Table[ROWS_TABLE][COLS_TABLE] = {{0}};
```

